### PR TITLE
Disable react/react-in-jsx-scope rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ export const config = [
               unnamedComponents: 'arrow-function',
             },
           ],
+          'react/react-in-jsx-scope': OFF,
           'react/prop-types': OFF,
           'jsx-a11y/label-has-associated-control': [
             ERROR,


### PR DESCRIPTION
This is just follow-up to #11, so it doesn't need its own changeset.