### PR TITLE
Fix detection of installed packages

### DIFF
--- a/.changeset/quick-hotels-speak.md
+++ b/.changeset/quick-hotels-speak.md
@@ -1,0 +1,5 @@
+---
+'@wkovacs64/eslint-config': patch
+---
+
+Fix detection of installed packages in consuming projects.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 //
 // Forked from https://github.com/epicweb-dev/config
 //
+import resolveFrom from 'resolve-from';
 import globals from 'globals';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
@@ -13,18 +14,16 @@ const ERROR = 'error';
 const WARN = 'warn';
 const OFF = 'off';
 
-const has = (pkg) =>
-  import(pkg).then(
-    () => true,
-    () => false,
-  );
+function has(pkgName) {
+  return Boolean(resolveFrom.silent(process.cwd(), pkgName));
+}
 
-const hasTypeScript = await has('typescript');
-const hasReact = await has('react');
-const hasTestingLibrary = await has('@testing-library/dom');
-const hasJestDom = await has('@testing-library/jest-dom');
-const hasVitest = await has('vitest');
-const hasPlaywright = await has('@playwright/test');
+const hasTypeScript = has('typescript');
+const hasReact = has('react');
+const hasTestingLibrary = has('@testing-library/dom');
+const hasJestDom = has('@testing-library/jest-dom');
+const hasVitest = has('vitest');
+const hasPlaywright = has('@playwright/test');
 
 const vitestFiles = ['**/__tests__/**/*', '**/*.test.*'];
 const testFiles = ['**/tests/**', '**/#tests/**', ...vitestFiles];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-testing-library": "^6.2.2",
         "eslint-plugin-vitest": "^0.5.4",
         "globals": "^15.3.0",
+        "resolve-from": "5.0.0",
         "typescript-eslint": "^8.0.0-alpha.20"
       },
       "devDependencies": {
@@ -4791,7 +4792,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "eslint-plugin-testing-library": "^6.2.2",
     "eslint-plugin-vitest": "^0.5.4",
     "globals": "^15.3.0",
+    "resolve-from": "5.0.0",
     "typescript-eslint": "^8.0.0-alpha.20"
   },
   "devDependencies": {


### PR DESCRIPTION
`import()` was rejecting when a package couldn't be imported directly for some reason (e.g., `vitest`, `@playwright/test`, etc.). This seems to be a more reliable way to detect if a particular package is installed in the consuming project.