### PR TITLE
Don't auto-merge minor versions of TypeScript

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,13 @@
   "major": {
     "automerge": false
   },
+  "packageRules": [
+    {
+      "matchPackageNames": ["typescript"],
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
+    }
+  ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0
 }


### PR DESCRIPTION
They don't follow semver, they treat minors as majors.