### PR TITLE
Remove last remnants of npm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,10 +102,10 @@ jobs:
         run: git clone --single-branch --depth 1 https://github.com/wKovacs64/use-stepper.git ~/example
 
       - name: 📦 Install package in the real repository
-        run: pnpm dlx yalc publish && cd ~/example && pnpm dlx yalc add --dev @wkovacs64/eslint-config && npm install --ignore-scripts
+        run: pnpm pack && cd ~/example && pnpm add --save-dev $GITHUB_WORKSPACE/wkovacs64-eslint-config-*.tgz
 
       - name: 🔬 Lint the real repository
-        run: cd ~/example && npm run lint
+        run: cd ~/example && pnpm run lint
 
   release:
     name: 🚀 Release


### PR DESCRIPTION
This pull request updates the CI workflow to improve how the package is installed and tested in an example repository. The main focus is on switching from `yalc` to a local tarball install and ensuring consistent use of `pnpm` for package management commands.

**CI Workflow Improvements:**

* Replaced `yalc` publish/add steps with `pnpm pack` to create a local tarball, and updated the install command in the example repository to use `pnpm add` with the generated tarball for more reliable and straightforward local testing.
* Changed the lint command in the example repository from `npm run lint` to `pnpm run lint` for consistency with the rest of the workflow.

This was missed in PR #87 