### PR TITLE
chore: replace prettier with oxfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: 📥 Install deps
         run: pnpm install
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: 📥 Install deps
         run: pnpm install
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: 📥 Install deps
         run: pnpm install
@@ -93,7 +93,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: 📥 Install deps
         run: pnpm install
@@ -127,7 +127,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           cache: pnpm
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: 📥 Install deps
         run: pnpm install
@@ -138,7 +138,7 @@ jobs:
         with:
           version: pnpm run changeset:version
           publish: pnpm run changeset:publish
-          commit: 'chore: release'
-          title: 'chore: release'
+          commit: "chore: release"
+          title: "chore: release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ env:
   CI: true
 
 jobs:
-  prettier:
-    name: 🅿️ Prettier
+  format:
+    name: 🔤 Oxfmt
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
@@ -110,7 +110,7 @@ jobs:
   release:
     name: 🚀 Release
     runs-on: ubuntu-latest
-    needs: [prettier, lint, typecheck, test]
+    needs: [format, lint, typecheck, test]
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ Temporary Items
 
 ### VisualStudioCode ###
 .vscode/*
-# !.vscode/settings.json
+!.vscode/settings.json
 # !.vscode/tasks.json
 # !.vscode/launch.json
 # !.vscode/extensions.json

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": [".changeset", "CHANGELOG.md", "pnpm-lock.yaml"]
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,0 @@
-# .gitignore and...
-
-.changeset
-package.json
-package-lock.json
-pnpm-lock.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "[javascript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[json]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[css]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[markdown]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[yaml]": { "editor.defaultFormatter": "oxc.oxc-vscode" }
+}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ default.
 #### `eslint.config.js`
 
 ```js
-import { defineConfig } from 'eslint/config';
-import baseConfig from '@wkovacs64/eslint-config';
+import { defineConfig } from "eslint/config";
+import baseConfig from "@wkovacs64/eslint-config";
 
 const config = defineConfig([
   baseConfig,
@@ -51,12 +51,10 @@ export default config;
 
 [npm-image]: https://img.shields.io/npm/v/@wkovacs64/eslint-config.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/@wkovacs64/eslint-config
-[ci-image]:
-  https://img.shields.io/github/actions/workflow/status/wKovacs64/eslint-config/ci.yml?logo=github&style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/wKovacs64/eslint-config/ci.yml?logo=github&style=flat-square
 [ci-url]: https://github.com/wKovacs64/eslint-config/actions?query=workflow%3Aci
 [changesets-image]: https://img.shields.io/badge/maintained%20with-changesets-blue?style=flat-square
 [changesets-url]: https://github.com/changesets/changesets
 [eslint]: https://eslint.org/
-[eslint-sharing]:
-  https://eslint.org/docs/latest/use/configure/configuration-files#using-a-shareable-configuration-package
+[eslint-sharing]: https://eslint.org/docs/latest/use/configure/configuration-files#using-a-shareable-configuration-package
 [eslint-ignores]: https://eslint.org/docs/latest/use/configure/migration-guide#ignoring-files

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,1 @@
-export { default } from './index.js';
+export { default } from "./index.js";

--- a/fixtures/index.ts
+++ b/fixtures/index.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
-import url from 'node:url';
+import path from "node:path";
+import url from "node:url";
 
 console.log(path.dirname(url.fileURLToPath(import.meta.url)));

--- a/fixtures/react.tsx
+++ b/fixtures/react.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 export function Counter() {
   const [count, setCount] = React.useState(0);

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 //
 // Forked from https://github.com/epicweb-dev/config
 //
-import globals from 'globals';
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import reactPlugin from 'eslint-plugin-react';
-import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
-import playwright from 'eslint-plugin-playwright';
-import astro from 'eslint-plugin-astro';
+import globals from "globals";
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactPlugin from "eslint-plugin-react";
+import jsxA11yPlugin from "eslint-plugin-jsx-a11y";
+import playwright from "eslint-plugin-playwright";
+import astro from "eslint-plugin-astro";
 
-const ERROR = 'error';
-const WARN = 'warn';
-const OFF = 'off';
+const ERROR = "error";
+const WARN = "warn";
+const OFF = "off";
 
 function has(pkgName) {
   try {
@@ -22,37 +22,37 @@ function has(pkgName) {
   }
 }
 
-const hasTypeScript = has('typescript');
-const hasReact = has('react');
-const hasTestingLibrary = has('@testing-library/dom');
-const hasJestDom = has('@testing-library/jest-dom');
-const hasVitest = has('vitest');
-const hasPlaywright = has('@playwright/test');
-const hasAstro = has('astro');
+const hasTypeScript = has("typescript");
+const hasReact = has("react");
+const hasTestingLibrary = has("@testing-library/dom");
+const hasJestDom = has("@testing-library/jest-dom");
+const hasVitest = has("vitest");
+const hasPlaywright = has("@playwright/test");
+const hasAstro = has("astro");
 
-const vitestFiles = ['**/__tests__/**/*', '**/*.test.*'];
-const testFiles = ['**/tests/**', '**/#tests/**', ...vitestFiles];
-const allPlaywrightFiles = ['**/playwright/**'];
-const playwrightTestFiles = ['**/playwright/**/*.spec.*'];
+const vitestFiles = ["**/__tests__/**/*", "**/*.test.*"];
+const testFiles = ["**/tests/**", "**/#tests/**", ...vitestFiles];
+const allPlaywrightFiles = ["**/playwright/**"];
+const playwrightTestFiles = ["**/playwright/**/*.spec.*"];
 
 export const config = [
   {
     ignores: [
-      '**/.astro/**',
-      '**/.cache/**',
-      '**/.react-router/**',
-      '**/.next/**',
-      '**/.vercel/**',
-      '**/node_modules/**',
-      '**/build/**',
-      '**/public/build/**',
-      '**/playwright-report/**',
-      '**/playwright-results/**',
-      '**/playwright/report/**',
-      '**/playwright/results/**',
-      '**/server-build/**',
-      '**/dist/**',
-      '**/coverage/**',
+      "**/.astro/**",
+      "**/.cache/**",
+      "**/.react-router/**",
+      "**/.next/**",
+      "**/.vercel/**",
+      "**/node_modules/**",
+      "**/build/**",
+      "**/public/build/**",
+      "**/playwright-report/**",
+      "**/playwright-results/**",
+      "**/playwright/report/**",
+      "**/playwright/results/**",
+      "**/server-build/**",
+      "**/dist/**",
+      "**/coverage/**",
     ],
   },
 
@@ -60,7 +60,7 @@ export const config = [
   eslint.configs.recommended,
   {
     plugins: {
-      import: (await import('eslint-plugin-import-x')).default,
+      import: (await import("eslint-plugin-import-x")).default,
     },
     languageOptions: {
       globals: {
@@ -69,15 +69,15 @@ export const config = [
       },
     },
     rules: {
-      'import/no-duplicates': [WARN, { 'prefer-inline': true }],
-      'import/order': [
+      "import/no-duplicates": [WARN, { "prefer-inline": true }],
+      "import/order": [
         WARN,
         {
           pathGroups: [
-            { pattern: '#*/**', group: 'internal' },
-            { pattern: '~/**', group: 'internal' },
+            { pattern: "#*/**", group: "internal" },
+            { pattern: "~/**", group: "internal" },
           ],
-          groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+          groups: ["builtin", "external", "internal", "parent", "sibling", "index"],
         },
       ],
     },
@@ -86,10 +86,10 @@ export const config = [
   // JSX/TSX files
   hasReact
     ? {
-        files: ['**/*.tsx', '**/*.jsx'],
+        files: ["**/*.tsx", "**/*.jsx"],
         plugins: {
           react: reactPlugin,
-          'jsx-a11y': jsxA11yPlugin,
+          "jsx-a11y": jsxA11yPlugin,
         },
         languageOptions: {
           parserOptions: {
@@ -101,25 +101,25 @@ export const config = [
         rules: {
           ...reactPlugin.configs.recommended.rules,
           ...jsxA11yPlugin.configs.recommended.rules,
-          'react/function-component-definition': [
-            'error',
+          "react/function-component-definition": [
+            "error",
             {
-              namedComponents: 'function-declaration',
-              unnamedComponents: 'arrow-function',
+              namedComponents: "function-declaration",
+              unnamedComponents: "arrow-function",
             },
           ],
-          'react/react-in-jsx-scope': OFF,
-          'react/prop-types': OFF,
-          'jsx-a11y/label-has-associated-control': [
+          "react/react-in-jsx-scope": OFF,
+          "react/prop-types": OFF,
+          "jsx-a11y/label-has-associated-control": [
             ERROR,
             {
-              assert: 'either',
+              assert: "either",
             },
           ],
         },
         settings: {
           react: {
-            version: 'detect',
+            version: "detect",
           },
         },
       }
@@ -128,38 +128,38 @@ export const config = [
   // react-hook rules are applicable in ts/js/tsx/jsx, but only with React as a dep
   hasReact
     ? {
-        files: ['**/*.ts?(x)', '**/*.js?(x)'],
+        files: ["**/*.ts?(x)", "**/*.js?(x)"],
         ignores: [...allPlaywrightFiles],
         plugins: {
-          'react-hooks': (await import('eslint-plugin-react-hooks')).default,
+          "react-hooks": (await import("eslint-plugin-react-hooks")).default,
         },
         rules: {
           // Core hooks rules
-          'react-hooks/rules-of-hooks': ERROR,
-          'react-hooks/exhaustive-deps': ERROR,
+          "react-hooks/rules-of-hooks": ERROR,
+          "react-hooks/exhaustive-deps": ERROR,
           // React Compiler rules
-          'react-hooks/config': ERROR,
-          'react-hooks/error-boundaries': ERROR,
-          'react-hooks/component-hook-factories': ERROR,
-          'react-hooks/gating': ERROR,
-          'react-hooks/globals': ERROR,
-          'react-hooks/immutability': ERROR,
-          'react-hooks/preserve-manual-memoization': ERROR,
-          'react-hooks/purity': ERROR,
-          'react-hooks/refs': ERROR,
-          'react-hooks/set-state-in-effect': ERROR,
-          'react-hooks/set-state-in-render': ERROR,
-          'react-hooks/static-components': ERROR,
-          'react-hooks/unsupported-syntax': ERROR,
-          'react-hooks/use-memo': ERROR,
-          'react-hooks/incompatible-library': ERROR,
+          "react-hooks/config": ERROR,
+          "react-hooks/error-boundaries": ERROR,
+          "react-hooks/component-hook-factories": ERROR,
+          "react-hooks/gating": ERROR,
+          "react-hooks/globals": ERROR,
+          "react-hooks/immutability": ERROR,
+          "react-hooks/preserve-manual-memoization": ERROR,
+          "react-hooks/purity": ERROR,
+          "react-hooks/refs": ERROR,
+          "react-hooks/set-state-in-effect": ERROR,
+          "react-hooks/set-state-in-render": ERROR,
+          "react-hooks/static-components": ERROR,
+          "react-hooks/unsupported-syntax": ERROR,
+          "react-hooks/use-memo": ERROR,
+          "react-hooks/incompatible-library": ERROR,
         },
       }
     : null,
 
   // JS, JSX, and CJS files
   {
-    files: ['**/*.{js,jsx,cjs}'],
+    files: ["**/*.{js,jsx,cjs}"],
     // most of these rules are useful for JS but not TS because TS handles these better
     rules: {
       // Blocked by https://github.com/import-js/eslint-plugin-import/issues/2132
@@ -169,13 +169,13 @@ export const config = [
       //     ignore: ['^#icons/icon', '^~/icons/icon', './icons-sprite.svg'],
       //   },
       // ],
-      'no-unused-vars': [
+      "no-unused-vars": [
         WARN,
         {
-          args: 'after-used',
-          argsIgnorePattern: '^_',
+          args: "after-used",
+          argsIgnorePattern: "^_",
           ignoreRestSiblings: true,
-          varsIgnorePattern: '^ignored',
+          varsIgnorePattern: "^ignored",
         },
       ],
     },
@@ -188,7 +188,7 @@ export const config = [
         ...tseslint.configs.recommended,
         ...tseslint.configs.stylistic,
         {
-          files: ['**/*.ts?(x)'],
+          files: ["**/*.ts?(x)"],
           languageOptions: {
             parserOptions: {
               parser: tseslint.parser,
@@ -196,18 +196,18 @@ export const config = [
             },
           },
           plugins: {
-            '@typescript-eslint': tseslint.plugin,
+            "@typescript-eslint": tseslint.plugin,
           },
           rules: {
-            '@typescript-eslint/ban-ts-comment': OFF,
-            '@typescript-eslint/consistent-type-assertions': [
+            "@typescript-eslint/ban-ts-comment": OFF,
+            "@typescript-eslint/consistent-type-assertions": [
               ERROR,
               {
-                assertionStyle: 'as',
-                objectLiteralTypeAssertions: 'allow-as-parameter',
+                assertionStyle: "as",
+                objectLiteralTypeAssertions: "allow-as-parameter",
               },
             ],
-            '@typescript-eslint/consistent-type-definitions': OFF,
+            "@typescript-eslint/consistent-type-definitions": OFF,
             // Note: use this rule _OR_ verbatimModuleSyntax in tsconfig.json - not both
             // '@typescript-eslint/consistent-type-imports': [
             //   ERROR,
@@ -217,48 +217,48 @@ export const config = [
             //     fixStyle: 'inline-type-imports',
             //   },
             // ],
-            '@typescript-eslint/explicit-module-boundary-types': OFF,
-            '@typescript-eslint/naming-convention': [
+            "@typescript-eslint/explicit-module-boundary-types": OFF,
+            "@typescript-eslint/naming-convention": [
               ERROR,
               {
-                selector: 'typeLike',
-                format: ['PascalCase'],
-                custom: { regex: '^I[A-Z]', match: false },
+                selector: "typeLike",
+                format: ["PascalCase"],
+                custom: { regex: "^I[A-Z]", match: false },
               },
             ],
-            '@typescript-eslint/no-confusing-void-expression': [
+            "@typescript-eslint/no-confusing-void-expression": [
               ERROR,
               {
                 ignoreArrowShorthand: true,
               },
             ],
-            '@typescript-eslint/no-explicit-any': OFF,
-            '@typescript-eslint/no-floating-promises': [
+            "@typescript-eslint/no-explicit-any": OFF,
+            "@typescript-eslint/no-floating-promises": [
               ERROR,
               {
                 ignoreIIFE: true,
               },
             ],
-            '@typescript-eslint/no-import-type-side-effects': ERROR,
-            'no-invalid-this': OFF,
-            '@typescript-eslint/no-invalid-this': ERROR,
-            'no-redeclare': OFF,
-            '@typescript-eslint/no-non-null-assertion': OFF,
-            '@typescript-eslint/no-redeclare': ERROR,
-            'no-shadow': OFF,
-            '@typescript-eslint/no-shadow': ERROR,
-            '@typescript-eslint/no-unnecessary-type-constraint': 'warn',
-            '@typescript-eslint/no-unused-vars': [
+            "@typescript-eslint/no-import-type-side-effects": ERROR,
+            "no-invalid-this": OFF,
+            "@typescript-eslint/no-invalid-this": ERROR,
+            "no-redeclare": OFF,
+            "@typescript-eslint/no-non-null-assertion": OFF,
+            "@typescript-eslint/no-redeclare": ERROR,
+            "no-shadow": OFF,
+            "@typescript-eslint/no-shadow": ERROR,
+            "@typescript-eslint/no-unnecessary-type-constraint": "warn",
+            "@typescript-eslint/no-unused-vars": [
               ERROR,
               {
-                vars: 'all',
-                args: 'after-used',
-                argsIgnorePattern: '^_',
+                vars: "all",
+                args: "after-used",
+                argsIgnorePattern: "^_",
                 ignoreRestSiblings: true,
               },
             ],
-            'no-use-before-define': OFF,
-            '@typescript-eslint/no-use-before-define': [
+            "no-use-before-define": OFF,
+            "@typescript-eslint/no-use-before-define": [
               ERROR,
               {
                 functions: false,
@@ -266,19 +266,19 @@ export const config = [
                 variables: true,
               },
             ],
-            '@typescript-eslint/prefer-nullish-coalescing': OFF,
-            '@typescript-eslint/restrict-template-expressions': [
+            "@typescript-eslint/prefer-nullish-coalescing": OFF,
+            "@typescript-eslint/restrict-template-expressions": [
               ERROR,
               {
                 allowBoolean: true,
                 allowNullish: true,
               },
             ],
-            '@typescript-eslint/require-await': OFF,
-            '@typescript-eslint/unified-signatures': 'warn',
+            "@typescript-eslint/require-await": OFF,
+            "@typescript-eslint/unified-signatures": "warn",
           },
           settings: {
-            'import/resolver': {
+            "import/resolver": {
               typescript: {
                 alwaysTryTypes: true,
               },
@@ -292,16 +292,16 @@ export const config = [
   // *.test.* in the filename. If a file doesn't match this assumption, then it
   // will not be allowed to import test files.
   {
-    files: ['**/*.ts?(x)', '**/*.js?(x)'],
+    files: ["**/*.ts?(x)", "**/*.js?(x)"],
     ignores: testFiles,
     rules: {
-      'no-restricted-imports': [
+      "no-restricted-imports": [
         ERROR,
         {
           patterns: [
             {
               group: testFiles,
-              message: 'Do not import test files in source files',
+              message: "Do not import test files in source files",
             },
           ],
         },
@@ -314,35 +314,35 @@ export const config = [
         files: testFiles,
         ignores: [...playwrightTestFiles],
         plugins: {
-          'testing-library': (await import('eslint-plugin-testing-library')).default,
+          "testing-library": (await import("eslint-plugin-testing-library")).default,
         },
         rules: {
-          'testing-library/await-async-events': ERROR,
-          'testing-library/await-async-queries': ERROR,
-          'testing-library/await-async-utils': ERROR,
-          'testing-library/consistent-data-testid': OFF,
-          'testing-library/no-await-sync-events': ERROR,
-          'testing-library/no-await-sync-queries': ERROR,
-          'testing-library/no-container': ERROR,
-          'testing-library/no-debugging-utils': OFF,
-          'testing-library/no-dom-import': [ERROR, 'react'],
-          'testing-library/no-global-regexp-flag-in-query': ERROR,
-          'testing-library/no-manual-cleanup': ERROR,
-          'testing-library/no-node-access': ERROR,
-          'testing-library/no-promise-in-fire-event': ERROR,
-          'testing-library/no-render-in-lifecycle': ERROR,
-          'testing-library/no-unnecessary-act': ERROR,
-          'testing-library/no-wait-for-multiple-assertions': ERROR,
-          'testing-library/no-wait-for-side-effects': ERROR,
-          'testing-library/no-wait-for-snapshot': ERROR,
-          'testing-library/prefer-explicit-assert': ERROR,
-          'testing-library/prefer-find-by': ERROR,
-          'testing-library/prefer-presence-queries': ERROR,
-          'testing-library/prefer-query-by-disappearance': ERROR,
-          'testing-library/prefer-query-matchers': OFF,
-          'testing-library/prefer-screen-queries': ERROR,
-          'testing-library/prefer-user-event': ERROR,
-          'testing-library/render-result-naming-convention': ERROR,
+          "testing-library/await-async-events": ERROR,
+          "testing-library/await-async-queries": ERROR,
+          "testing-library/await-async-utils": ERROR,
+          "testing-library/consistent-data-testid": OFF,
+          "testing-library/no-await-sync-events": ERROR,
+          "testing-library/no-await-sync-queries": ERROR,
+          "testing-library/no-container": ERROR,
+          "testing-library/no-debugging-utils": OFF,
+          "testing-library/no-dom-import": [ERROR, "react"],
+          "testing-library/no-global-regexp-flag-in-query": ERROR,
+          "testing-library/no-manual-cleanup": ERROR,
+          "testing-library/no-node-access": ERROR,
+          "testing-library/no-promise-in-fire-event": ERROR,
+          "testing-library/no-render-in-lifecycle": ERROR,
+          "testing-library/no-unnecessary-act": ERROR,
+          "testing-library/no-wait-for-multiple-assertions": ERROR,
+          "testing-library/no-wait-for-side-effects": ERROR,
+          "testing-library/no-wait-for-snapshot": ERROR,
+          "testing-library/prefer-explicit-assert": ERROR,
+          "testing-library/prefer-find-by": ERROR,
+          "testing-library/prefer-presence-queries": ERROR,
+          "testing-library/prefer-query-by-disappearance": ERROR,
+          "testing-library/prefer-query-matchers": OFF,
+          "testing-library/prefer-screen-queries": ERROR,
+          "testing-library/prefer-user-event": ERROR,
+          "testing-library/render-result-naming-convention": ERROR,
         },
       }
     : null,
@@ -352,20 +352,20 @@ export const config = [
         files: testFiles,
         ignores: [...playwrightTestFiles],
         plugins: {
-          'jest-dom': (await import('eslint-plugin-jest-dom')).default,
+          "jest-dom": (await import("eslint-plugin-jest-dom")).default,
         },
         rules: {
-          'jest-dom/prefer-checked': ERROR,
-          'jest-dom/prefer-empty': ERROR,
-          'jest-dom/prefer-enabled-disabled': ERROR,
-          'jest-dom/prefer-focus': ERROR,
-          'jest-dom/prefer-in-document': ERROR,
-          'jest-dom/prefer-required': ERROR,
-          'jest-dom/prefer-to-have-attribute': ERROR,
-          'jest-dom/prefer-to-have-class': ERROR,
-          'jest-dom/prefer-to-have-style': ERROR,
-          'jest-dom/prefer-to-have-text-content': ERROR,
-          'jest-dom/prefer-to-have-value': ERROR,
+          "jest-dom/prefer-checked": ERROR,
+          "jest-dom/prefer-empty": ERROR,
+          "jest-dom/prefer-enabled-disabled": ERROR,
+          "jest-dom/prefer-focus": ERROR,
+          "jest-dom/prefer-in-document": ERROR,
+          "jest-dom/prefer-required": ERROR,
+          "jest-dom/prefer-to-have-attribute": ERROR,
+          "jest-dom/prefer-to-have-class": ERROR,
+          "jest-dom/prefer-to-have-style": ERROR,
+          "jest-dom/prefer-to-have-text-content": ERROR,
+          "jest-dom/prefer-to-have-value": ERROR,
         },
       }
     : null,
@@ -375,12 +375,12 @@ export const config = [
         files: testFiles,
         ignores: [...playwrightTestFiles],
         plugins: {
-          vitest: (await import('@vitest/eslint-plugin')).default,
+          vitest: (await import("@vitest/eslint-plugin")).default,
         },
         rules: {
           // you don't want the editor to autofix this, but we do want to be
           // made aware of it
-          'vitest/no-focused-tests': [WARN, { fixable: false }],
+          "vitest/no-focused-tests": [WARN, { fixable: false }],
         },
       }
     : null,
@@ -388,14 +388,14 @@ export const config = [
   // Astro support
   ...(hasAstro
     ? [
-        ...astro.configs['flat/recommended'],
+        ...astro.configs["flat/recommended"],
         // No idea why this override is needed as it should inherit from the base config, but for
         // some reason, enabling the Astro plugin screws that up and it tries to enforce interfaces
         // over types. 🤷‍♂️
         {
-          files: ['**/*.astro'],
+          files: ["**/*.astro"],
           rules: {
-            '@typescript-eslint/consistent-type-definitions': OFF,
+            "@typescript-eslint/consistent-type-definitions": OFF,
           },
         },
       ]
@@ -404,7 +404,7 @@ export const config = [
   hasPlaywright
     ? {
         files: playwrightTestFiles,
-        ...playwright.configs['flat/recommended'],
+        ...playwright.configs["flat/recommended"],
       }
     : null,
 ].filter(Boolean);

--- a/package.json
+++ b/package.json
@@ -35,14 +35,13 @@
     "changeset": "changeset",
     "changeset:version": "changeset version && pnpm install",
     "changeset:publish": "changeset publish",
-    "format": "prettier --cache --write .",
-    "format:check": "prettier --cache --check .",
+    "format": "oxfmt --write .",
+    "format:check": "oxfmt --check .",
     "lint": "eslint .",
     "typecheck": "tsc"
   },
   "private": false,
-  "prettier": "@wkovacs64/prettier-config",
-  "publishConfig": {
+"publishConfig": {
     "access": "public"
   },
   "engines": {
@@ -69,9 +68,8 @@
     "@types/node": "24.10.13",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "@wkovacs64/prettier-config": "4.2.4",
     "eslint": "^9.39.3",
-    "prettier": "3.8.1",
+    "oxfmt": "0.35.0",
     "typescript": "5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,35 +1,39 @@
 {
   "name": "@wkovacs64/eslint-config",
   "version": "7.14.0",
+  "private": false,
   "description": "@wKovacs64 ESLint config",
   "keywords": [
     "eslint",
-    "eslintconfig",
-    "eslintplugin",
     "eslint-config",
     "eslint-plugin",
+    "eslintconfig",
+    "eslintplugin",
     "wkovacs64"
   ],
+  "homepage": "https://github.com/wKovacs64/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/wKovacs64/eslint-config/issues"
+  },
+  "license": "MIT",
   "author": {
     "name": "Justin Hall",
     "email": "justin.r.hall@gmail.com"
   },
-  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/wKovacs64/eslint-config.git"
+  },
+  "files": [
+    "index.js"
+  ],
   "type": "module",
   "main": "index.js",
   "exports": {
     ".": "./index.js",
     "./package.json": "./package.json"
   },
-  "files": [
-    "index.js"
-  ],
-  "homepage": "https://github.com/wKovacs64/eslint-config#readme",
-  "repository": {
-    "url": "git+https://github.com/wKovacs64/eslint-config.git"
-  },
-  "bugs": {
-    "url": "https://github.com/wKovacs64/eslint-config/issues"
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "changeset": "changeset",
@@ -40,14 +44,6 @@
     "lint": "eslint .",
     "typecheck": "tsc"
   },
-  "private": false,
-"publishConfig": {
-    "access": "public"
-  },
-  "engines": {
-    "node": "^18.18.0 || >=20.0.0"
-  },
-  "packageManager": "pnpm@10.30.1",
   "dependencies": {
     "@eslint/js": "^9.39.3",
     "@vitest/eslint-plugin": "^1.6.9",
@@ -71,5 +67,9 @@
     "eslint": "^9.39.3",
     "oxfmt": "0.35.0",
     "typescript": "5.9.3"
-  }
+  },
+  "engines": {
+    "node": "^18.18.0 || >=20.0.0"
+  },
+  "packageManager": "pnpm@10.30.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,23 +60,17 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
-      '@wkovacs64/prettier-config':
-        specifier: 4.2.4
-        version: 4.2.4(prettier@3.8.1)
       eslint:
         specifier: ^9.39.3
         version: 9.39.3
-      prettier:
-        specifier: 3.8.1
-        version: 3.8.1
+      oxfmt:
+        specifier: 0.35.0
+        version: 0.35.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
 
 packages:
-
-  '@astrojs/compiler@2.13.0':
-    resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
 
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
@@ -336,6 +330,128 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxfmt/binding-android-arm-eabi@0.35.0':
+    resolution: {integrity: sha512-BaRKlM3DyG81y/xWTsE6gZiv89F/3pHe2BqX2H4JbiB8HNVlWWtplzgATAE5IDSdwChdeuWLDTQzJ92Lglw3ZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.35.0':
+    resolution: {integrity: sha512-/O+EbuAJYs6nde/anv+aID6uHsGQApyE9JtYBo/79KyU8e6RBN3DMbT0ix97y1SOnCglurmL2iZ+hlohjP2PnQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.35.0':
+    resolution: {integrity: sha512-pGqRtqlNdn9d4VrmGUWVyQjkw79ryhI6je9y2jfqNUIZCfqceob+R97YYAoG7C5TFyt8ILdLVoN+L2vw/hSFyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.35.0':
+    resolution: {integrity: sha512-8GmsDcSozTPjrCJeGpp+sCmS9+9V5yRrdEZ1p/sTWxPG5nYeAfSLuS0nuEYjXSO+CtdSbStIW6dxa+4NM58yRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.35.0':
+    resolution: {integrity: sha512-QyfKfTe0ytHpFKHAcHCGQEzN45QSqq1AHJOYYxQMgLM3KY4xu8OsXHpCnINjDsV4XGnQzczJDU9e04Zmd8XqIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.35.0':
+    resolution: {integrity: sha512-u+kv3JD6P3J38oOyUaiCqgY5TNESzBRZJ5lyZQ6c2czUW2v5SIN9E/KWWa9vxoc+P8AFXQFUVrdzGy1tK+nbPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.35.0':
+    resolution: {integrity: sha512-1NiZroCiV57I7Pf8kOH4XGR366kW5zir3VfSMBU2D0V14GpYjiYmPYFAoJboZvp8ACnZKUReWyMkNKSa5ad58A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.35.0':
+    resolution: {integrity: sha512-7Q0Xeg7ZnW2nxnZ4R7aF6DEbCFls4skgHZg+I63XitpNvJCbVIU8MFOTZlvZGRsY9+rPgWPQGeUpLHlyx0wvMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.35.0':
+    resolution: {integrity: sha512-5Okqi+uhYFxwKz8hcnUftNNwdm8BCkf6GSCbcz9xJxYMm87k1E4p7PEmAAbhLTk7cjSdDre6TDL0pDzNX+Y22Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
+    resolution: {integrity: sha512-9k66pbZQXM/lBJWys3Xbc5yhl4JexyfqkEf/tvtq8976VIJnLAAL3M127xHA3ifYSqxdVHfVGTg84eiBHCGcNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
+    resolution: {integrity: sha512-aUcY9ofKPtjO52idT6t0SAQvEF6ctjzUQa1lLp7GDsRpSBvuTrBQGeq0rYKz3gN8dMIQ7mtMdGD9tT4LhR8jAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.35.0':
+    resolution: {integrity: sha512-C6yhY5Hvc2sGM+mCPek9ZLe5xRUOC/BvhAt2qIWFAeXMn4il04EYIjl3DsWiJr0xDMTJhvMOmD55xTRPlNp39w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.35.0':
+    resolution: {integrity: sha512-RG2hlvOMK4OMZpO3mt8MpxLQ0AAezlFqhn5mI/g5YrVbPFyoCv9a34AAvbSJS501ocOxlFIRcKEuw5hFvddf9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.35.0':
+    resolution: {integrity: sha512-wzmh90Pwvqj9xOKHJjkQYBpydRkaXG77ZvDz+iFDRRQpnqIEqGm5gmim2s6vnZIkDGsvKCuTdtxm0GFmBjM1+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.35.0':
+    resolution: {integrity: sha512-+HCqYCJPCUy5I+b2cf+gUVaApfgtoQT3HdnSg/l7NIcLHOhKstlYaGyrFZLmUpQt4WkFbpGKZZayG6zjRU0KFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.35.0':
+    resolution: {integrity: sha512-kFYmWfR9YL78XyO5ws+1dsxNvZoD973qfVMNFOS4e9bcHXGF7DvGC2tY5UDFwyMCeB33t3sDIuGONKggnVNSJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.35.0':
+    resolution: {integrity: sha512-uD/NGdM65eKNCDGyTGdO8e9n3IHX+wwuorBvEYrPJXhDXL9qz6gzddmXH8EN04ejUXUujlq4FsoSeCfbg0Y+Jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.35.0':
+    resolution: {integrity: sha512-oSRD2k8J2uxYDEKR2nAE/YTY9PobOEnhZgCmspHu0+yBQ665yH8lFErQVSTE7fcGJmJp/cC6322/gc8VFuQf7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.35.0':
+    resolution: {integrity: sha512-WCDJjlS95NboR0ugI2BEwzt1tYvRDorDRM9Lvctls1SLyKYuNRCyrPwp1urUPFBnwgBNn9p2/gnmo7gFMySRoQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -578,10 +694,6 @@ packages:
         optional: true
       vitest:
         optional: true
-
-  '@wkovacs64/prettier-config@4.2.4':
-    resolution: {integrity: sha512-4rQZeoTWrh+xOFIZDJGIL+4c1vaUURePRriTkJCKGjZq9obGQ52Vr7SW9pACXA2i3kncKjU2uZBRDn42BlksUw==}
-    engines: {node: '>= 18'}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1499,6 +1611,11 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxfmt@0.35.0:
+    resolution: {integrity: sha512-QYeXWkP+aLt7utt5SLivNIk09glWx9QE235ODjgcEZ3sd1VMaUBSpLymh6ZRCA76gD2rMP4bXanUz/fx+nLM9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -1580,73 +1697,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-plugin-astro@0.14.1:
-    resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
-    engines: {node: ^14.15.0 || >=16.0.0}
-
-  prettier-plugin-tailwindcss@0.7.2:
-    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
-    engines: {node: '>=20.19'}
-    peerDependencies:
-      '@ianvs/prettier-plugin-sort-imports': '*'
-      '@prettier/plugin-hermes': '*'
-      '@prettier/plugin-oxc': '*'
-      '@prettier/plugin-pug': '*'
-      '@shopify/prettier-plugin-liquid': '*'
-      '@trivago/prettier-plugin-sort-imports': '*'
-      '@zackad/prettier-plugin-twig': '*'
-      prettier: ^3.0
-      prettier-plugin-astro: '*'
-      prettier-plugin-css-order: '*'
-      prettier-plugin-jsdoc: '*'
-      prettier-plugin-marko: '*'
-      prettier-plugin-multiline-arrays: '*'
-      prettier-plugin-organize-attributes: '*'
-      prettier-plugin-organize-imports: '*'
-      prettier-plugin-sort-imports: '*'
-      prettier-plugin-svelte: '*'
-    peerDependenciesMeta:
-      '@ianvs/prettier-plugin-sort-imports':
-        optional: true
-      '@prettier/plugin-hermes':
-        optional: true
-      '@prettier/plugin-oxc':
-        optional: true
-      '@prettier/plugin-pug':
-        optional: true
-      '@shopify/prettier-plugin-liquid':
-        optional: true
-      '@trivago/prettier-plugin-sort-imports':
-        optional: true
-      '@zackad/prettier-plugin-twig':
-        optional: true
-      prettier-plugin-astro:
-        optional: true
-      prettier-plugin-css-order:
-        optional: true
-      prettier-plugin-jsdoc:
-        optional: true
-      prettier-plugin-marko:
-        optional: true
-      prettier-plugin-multiline-arrays:
-        optional: true
-      prettier-plugin-organize-attributes:
-        optional: true
-      prettier-plugin-organize-imports:
-        optional: true
-      prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-svelte:
-        optional: true
-
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
-    hasBin: true
-
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prop-types@15.8.1:
@@ -1703,9 +1756,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  s.color@0.0.15:
-    resolution: {integrity: sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -1720,9 +1770,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  sass-formatter@0.7.9:
-    resolution: {integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1835,9 +1882,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  suf-log@2.5.3:
-    resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1857,6 +1901,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1980,8 +2028,6 @@ packages:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
 
 snapshots:
-
-  '@astrojs/compiler@2.13.0': {}
 
   '@astrojs/compiler@2.13.1': {}
 
@@ -2391,6 +2437,63 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxfmt/binding-android-arm-eabi@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.35.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.35.0':
+    optional: true
+
   '@pkgr/core@0.2.9': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -2628,28 +2731,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@wkovacs64/prettier-config@4.2.4(prettier@3.8.1)':
-    dependencies:
-      prettier-plugin-astro: 0.14.1
-      prettier-plugin-tailwindcss: 0.7.2(prettier-plugin-astro@0.14.1)(prettier@3.8.1)
-    transitivePeerDependencies:
-      - '@ianvs/prettier-plugin-sort-imports'
-      - '@prettier/plugin-hermes'
-      - '@prettier/plugin-oxc'
-      - '@prettier/plugin-pug'
-      - '@shopify/prettier-plugin-liquid'
-      - '@trivago/prettier-plugin-sort-imports'
-      - '@zackad/prettier-plugin-twig'
-      - prettier
-      - prettier-plugin-css-order
-      - prettier-plugin-jsdoc
-      - prettier-plugin-marko
-      - prettier-plugin-multiline-arrays
-      - prettier-plugin-organize-attributes
-      - prettier-plugin-organize-imports
-      - prettier-plugin-sort-imports
-      - prettier-plugin-svelte
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -3713,6 +3794,30 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxfmt@0.35.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.35.0
+      '@oxfmt/binding-android-arm64': 0.35.0
+      '@oxfmt/binding-darwin-arm64': 0.35.0
+      '@oxfmt/binding-darwin-x64': 0.35.0
+      '@oxfmt/binding-freebsd-x64': 0.35.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.35.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.35.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.35.0
+      '@oxfmt/binding-linux-arm64-musl': 0.35.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.35.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.35.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.35.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.35.0
+      '@oxfmt/binding-linux-x64-gnu': 0.35.0
+      '@oxfmt/binding-linux-x64-musl': 0.35.0
+      '@oxfmt/binding-openharmony-arm64': 0.35.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.35.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.35.0
+      '@oxfmt/binding-win32-x64-msvc': 0.35.0
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -3776,21 +3881,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-astro@0.14.1:
-    dependencies:
-      '@astrojs/compiler': 2.13.0
-      prettier: 3.8.1
-      sass-formatter: 0.7.9
-
-  prettier-plugin-tailwindcss@0.7.2(prettier-plugin-astro@0.14.1)(prettier@3.8.1):
-    dependencies:
-      prettier: 3.8.1
-    optionalDependencies:
-      prettier-plugin-astro: 0.14.1
-
   prettier@2.8.8: {}
-
-  prettier@3.8.1: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -3853,8 +3944,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  s.color@0.0.15: {}
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -3875,10 +3964,6 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
-
-  sass-formatter@0.7.9:
-    dependencies:
-      suf-log: 2.5.3
 
   semver@6.3.1: {}
 
@@ -4020,10 +4105,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  suf-log@2.5.3:
-    dependencies:
-      s.color: 0.0.15
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -4040,6 +4121,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@2.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
This pull request migrates the project's code formatting and CI workflow from Prettier to Oxfmt, updates related configuration files, and standardizes code style to use double quotes throughout the codebase. The most significant changes include introducing Oxfmt configuration, updating CI job names and dependencies, removing Prettier settings, and refactoring code and documentation for consistency.

**Formatting Tool Migration**
* Added `.oxfmtrc.json` to configure Oxfmt as the new code formatter and updated `.vscode/settings.json` to use `oxc.oxc-vscode` as the default formatter for relevant file types. [[1]](diffhunk://#diff-ba6bdb5315b18041509bd0925c6394aa9250917b715ab46ca0a36231c566c8e5R1-R4) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R12)
* Removed `.prettierignore` since Prettier is no longer used.

**CI Workflow Updates**
* Renamed the CI job from `prettier` to `format` and updated the release job to depend on `format` instead of `prettier`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL16-R17) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL113-R113)
* Standardized `node-version-file` and other string values in `.github/workflows/ci.yml` to use double quotes for consistency. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL30-R30) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL52-R52) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R74) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL96-R96) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL130-R130) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL141-R142)

**Codebase Refactoring**
* Refactored all code files (e.g., `index.js`, `eslint.config.js`, `fixtures/*`) to use double quotes instead of single quotes, ensuring consistency with the new formatting rules. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L4-R14) [[2]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L1-R1) [[3]](diffhunk://#diff-5c14ee9d0e0e7311d08d2934e32a66e039b3f77051703b7ef903ec7807de8a63L1-R2) [[4]](diffhunk://#diff-a6dcef63c8b6211f4f9c442c7256435c8d6735bfa79c711b1521c0a7365b950aL1-R1)
* Updated ESLint configuration and rules in `index.js` to use double quotes and improved clarity in rule definitions and file patterns. [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L25-R63) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L72-R80) [[3]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L89-R92) [[4]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L104-R122) [[5]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L131-R162) [[6]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L172-R178) [[7]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L191-R210)

**Documentation Updates**
* Updated `README.md` code examples and badge references to use double quotes and fixed formatting for badge links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R59)